### PR TITLE
Fix content jumping caused by disappearing reset button

### DIFF
--- a/client/pages/NewEvent.js
+++ b/client/pages/NewEvent.js
@@ -384,15 +384,15 @@ class NewEvent extends React.Component {
             {!this.state.dateOrDay ?
               <div>
                 <h6 styleName="heading-dates">What dates might work for you?</h6>
-                {from && to &&
-                  <p className="center">
-                    <a
-                      className="btn-flat"
-                      href="#reset"
-                      onClick={this.handleResetClick}
-                    >Reset</a>
-                  </p>
-                }
+                <p className="center" styleName="reset-button">
+                  {from && to &&
+                      <a
+                        className="btn-flat"
+                        href="#reset"
+                        onClick={this.handleResetClick}
+                      >Reset</a>
+                  }
+                </p>
                 <DayPicker
                   numberOfMonths={2}
                   fromMonth={new Date()}

--- a/client/styles/new-event.css
+++ b/client/styles/new-event.css
@@ -40,3 +40,7 @@ h1 {
   composes: heading;
   margin-top: 15px;
 }
+
+.reset-button {
+  min-height: 36px;
+}


### PR DESCRIPTION
Not sure how responsive this solution is, but I guess we'll try and fix that when we actually fix the rest of the responsive shit