### PR TITLE
Grid times range fix

### DIFF
--- a/client/components/AvailabilityGrid/AvailabilityGrid.js
+++ b/client/components/AvailabilityGrid/AvailabilityGrid.js
@@ -61,13 +61,21 @@ class AvailabilityGrid extends Component {
   }
 
   static createTimesRange(dates) {
+    // get the first to from dates from the dates range.
+    // so he has the hole hours ranges
     const startDate = moment(dates[0].fromDate);
     const endDate = moment(dates[0].toDate);
     const hour = endDate.get('hour');
     const minute = endDate.get('minute');
-    const endDateToRange = moment(endDate).startOf('date').hour(hour).minute(minute);
-    const dateRange = moment.range(startDate, endDateToRange);
+    const endDateToRange = moment(startDate).startOf('date').hour(hour).minute(minute);
+    console.log(startDate._d, endDateToRange._d);
+    let dateRange = moment.range(startDate, endDateToRange);
+    // if the range has midnight then ajust the range for end at next day;
+    if (endDateToRange.hour() < startDate.hour()) {
+      dateRange = moment.range(startDate, moment(endDateToRange).add(1, 'days'));
+    }
     const timesRange = Array.from(dateRange.by('minutes', { exclusive: true, step: 15 }));
+    console.log('timesRange', dateRange.toString());
     timesRange.forEach(time => console.log(time._d));
     // correct the date value since the range maybe create dates thats goes to the next day.
     const timesRangeFinal = timesRange.map(time => moment(startDate).startOf('date').hour(time.get('hour')).minute(time.get('minute')));
@@ -77,6 +85,8 @@ class AvailabilityGrid extends Component {
       }
       return 1;
     });
+    console.log('timetimesRangeFinalsRange');
+    timesRangeFinal.forEach(time => console.log(time._d));
     return timesRangeFinal;
   }
 

--- a/client/components/AvailabilityGrid/AvailabilityGrid.js
+++ b/client/components/AvailabilityGrid/AvailabilityGrid.js
@@ -65,9 +65,10 @@ class AvailabilityGrid extends Component {
     const endDate = moment(dates[0].toDate);
     const hour = endDate.get('hour');
     const minute = endDate.get('minute');
-    const endDateToRange = moment(startDate).startOf('date').hour(hour).minute(minute);
+    const endDateToRange = moment(endDate).startOf('date').hour(hour).minute(minute);
     const dateRange = moment.range(startDate, endDateToRange);
     const timesRange = Array.from(dateRange.by('minutes', { exclusive: true, step: 15 }));
+    timesRange.forEach(time => console.log(time._d));
     // correct the date value since the range maybe create dates thats goes to the next day.
     const timesRangeFinal = timesRange.map(time => moment(startDate).startOf('date').hour(time.get('hour')).minute(time.get('minute')));
     timesRangeFinal.sort((a, b) => {

--- a/client/components/AvailabilityGrid/AvailabilityGrid.js
+++ b/client/components/AvailabilityGrid/AvailabilityGrid.js
@@ -68,15 +68,12 @@ class AvailabilityGrid extends Component {
     const hour = endDate.get('hour');
     const minute = endDate.get('minute');
     const endDateToRange = moment(startDate).startOf('date').hour(hour).minute(minute);
-    console.log(startDate._d, endDateToRange._d);
     let dateRange = moment.range(startDate, endDateToRange);
     // if the range has midnight then ajust the range for end at next day;
     if (endDateToRange.hour() < startDate.hour()) {
       dateRange = moment.range(startDate, moment(endDateToRange).add(1, 'days'));
     }
     const timesRange = Array.from(dateRange.by('minutes', { exclusive: true, step: 15 }));
-    console.log('timesRange', dateRange.toString());
-    timesRange.forEach(time => console.log(time._d));
     // correct the date value since the range maybe create dates thats goes to the next day.
     const timesRangeFinal = timesRange.map(time => moment(startDate).startOf('date').hour(time.get('hour')).minute(time.get('minute')));
     timesRangeFinal.sort((a, b) => {
@@ -85,8 +82,6 @@ class AvailabilityGrid extends Component {
       }
       return 1;
     });
-    console.log('timetimesRangeFinalsRange');
-    timesRangeFinal.forEach(time => console.log(time._d));
     return timesRangeFinal;
   }
 

--- a/client/components/CellGrid/cell-grid.css
+++ b/client/components/CellGrid/cell-grid.css
@@ -18,6 +18,7 @@
 
 .cellGridJump {
   border-left: 6px double #787878;
+  width: 18px;
 }
 .cellBorderHour {
   border-left: 1px solid rgb(120, 120, 120);


### PR DESCRIPTION
Fix the TimesRange when you got a event with more then 12 hours and one of the guests are at a time zone thats the original times range invade the next day. 
Add a shift capability to the grid that can deal with ranges that have a block of non used hours, in function of the original ranges selected from the user