### PR TITLE
Pinned times to the top of the screen

### DIFF
--- a/client/components/AvailabilityGrid/availability-grid.css
+++ b/client/components/AvailabilityGrid/availability-grid.css
@@ -44,6 +44,9 @@
   display: flex;
   flex-direction: row;
   margin: 0 0 0 72px;
+  position: sticky;
+  top: 0;
+  background: white;
 }
 
 .info {


### PR DESCRIPTION
Added `position: sticky` so that the times are always visible at the top of the screen.

Shouldn't effect any browsers that don't support sticky.

Closes #462.