### PR TITLE
Change width to max-width to not stretch images

### DIFF
--- a/client/pages/home/home.css
+++ b/client/pages/home/home.css
@@ -8,7 +8,7 @@
 
 .main img {
 	max-height: 80vh;
-	width: 50vw;
+	max-width: 50vw;
 	margin: 10px;
 }
 


### PR DESCRIPTION
This PR is for the issue 464.

The images on the home page we're blurry and deformed.
The following CSS was being applied to the images.

`.main img {
	max-height: 80vh;
	width: 50vw;
	margin: 10px;
}`

The width property would expand the images above their resolution on large displays. Then the max-height property would deform the image.

Changing width to max-width makes sure the images aren't expanded but keeps the same formatting the same as before for smaller displays.

closes #464 